### PR TITLE
Raise an exception in SqlAlchemyStore.log_param only if param value changed

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -958,12 +958,13 @@ class SqlAlchemyStore(AbstractStore):
                 existing_params = [p.value for p in run.params if p.key == param.key]
                 if len(existing_params) > 0:
                     old_value = existing_params[0]
-                    raise MlflowException(
-                        "Changing param values is not allowed. Param with key='{}' was already"
-                        " logged with value='{}' for run ID='{}'. Attempted logging new value"
-                        " '{}'.".format(param.key, old_value, run_id, param.value),
-                        INVALID_PARAMETER_VALUE,
-                    )
+                    if old_value != param.value:
+                        raise MlflowException(
+                            "Changing param values is not allowed. Param with key='{}' was already"
+                            " logged with value='{}' for run ID='{}'. Attempted logging new value"
+                            " '{}'.".format(param.key, old_value, run_id, param.value),
+                            INVALID_PARAMETER_VALUE,
+                        )
                 else:
                     raise
 


### PR DESCRIPTION
## Related Issues/PRs

Similar PR, but for _log_params: https://github.com/mlflow/mlflow/pull/7057

## What changes are proposed in this pull request?

`MlflowException("Changing param values is not allowed..."` shouldn't be raised if the values didn't change - but that wasn't the case as this was not checked. The change is adding an `if` statement checking whether the param value actually changed.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

To reproduce the issue, create the client.py file:
```python
import mlflow
import threading

ITERATIONS = 1000

def log_param():
	for _ in range(ITERATIONS):
		mlflow.log_param('key', 'val')

mlflow.set_tracking_uri('http://localhost:5000')
with mlflow.start_run():
	t1 = threading.Thread(target=log_param)
	t2 = threading.Thread(target=log_param)
	t1.start()
	t2.start()
	t1.join()
	t2.join()
```
Let's also create a venv:
```
$ python3.8 -m venv mlflow
$ source mlflow/bin/activate
(mlflow) $ pip install mlflow==2.2.2
```
And run the server in that venv:
```
(mlflow) $ mlflow server --backend-store-uri=sqlite:///mlflow.db
```
Keep that console tab open. In a new one, run client.py in our venv:
```
$ source mlflow/bin/activate
(mlflow) $ python3.8 client.py
```
After some time you should see INVALID_PARAMETER_VALUE exception. If not, re-run the script. Usually it takes only a couple of runs to trigger the exception.

After applying the proposed patch, you won't see the exception.

In our system, log_param was called from kedro pipeline, specifically https://github.com/Galileo-Galilei/kedro-mlflow calls it in before_node_run hook. So sometimes we saw the whole pipeline failing because of INVALID_PARAMETER_VALUE (and param values didn't change).

The logic now will be consistent with _log_params (that log_batch calls): https://github.com/AdamStelmaszczyk/mlflow/blob/4d1653da42c33ee9e89af7ec649bd2498895377a/mlflow/store/tracking/sqlalchemy_store.py#L983 which was fixed in https://github.com/mlflow/mlflow/pull/7057.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

SqlAlchemyStore.log_param() can now be called multiple times (and from multiple threads) with the same param values.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
